### PR TITLE
initialize controller according to showType

### DIFF
--- a/lib/src/base/base.dart
+++ b/lib/src/base/base.dart
@@ -59,7 +59,7 @@ class _BaseView extends State<BaseView> {
   FixedExtentScrollController provinceController;
   FixedExtentScrollController cityController;
   FixedExtentScrollController areaController;
-  FixedExtentScrollController villageController;// 增加第4级(村/镇)选择
+  FixedExtentScrollController villageController; // 增加第4级(村/镇)选择
 
   // 所有省的列表. 因为性能等综合原因,
   // 没有一次性构建整个以国为根的树. 动态的构建以省为根的树, 效率高.
@@ -69,7 +69,7 @@ class _BaseView extends State<BaseView> {
   Point targetProvince;
   Point targetCity;
   Point targetArea;
-  Point targetVillage;// 增加第4级(村/镇)选择
+  Point targetVillage; // 增加第4级(村/镇)选择
 
   @override
   void initState() {
@@ -91,10 +91,19 @@ class _BaseView extends State<BaseView> {
   }
 
   void dispose() {
-    provinceController.dispose();
-    cityController.dispose();
-    areaController.dispose();
-    villageController.dispose();// 增加第4级(村/镇)选择
+    ShowType showType = widget.showType;
+    if (showType.contain(ShowType.p)) {
+      provinceController.dispose();
+    }
+    if (showType.contain(ShowType.c)) {
+      cityController.dispose();
+    }
+    if (showType.contain(ShowType.a)) {
+      areaController.dispose();
+    }
+    if (showType.contain(ShowType.v)) {
+      villageController.dispose();
+    }
     if (_changeTimer != null && _changeTimer.isActive) {
       _changeTimer.cancel();
     }
@@ -103,22 +112,28 @@ class _BaseView extends State<BaseView> {
 
   // 初始化controller, 为了使给定的默认值, 在选框的中心位置
   void _initController() {
-    provinceController = new FixedExtentScrollController(
-        initialItem:
-            provinces.indexWhere((Point p) => p.code == targetProvince.code));
-
-    cityController = new FixedExtentScrollController(
-        initialItem: targetProvince.child
-            .indexWhere((Point p) => p.code == targetCity.code));
-
-    areaController = new FixedExtentScrollController(
-        initialItem: targetCity.child
-            .indexWhere((Point p) => p.code == targetArea.code));
-
+    ShowType showType = widget.showType;
+    if (showType.contain(ShowType.p)) {
+      provinceController = new FixedExtentScrollController(
+          initialItem:
+              provinces.indexWhere((Point p) => p.code == targetProvince.code));
+    }
+    if (showType.contain(ShowType.c)) {
+      cityController = new FixedExtentScrollController(
+          initialItem: targetProvince.child
+              .indexWhere((Point p) => p.code == targetCity.code));
+    }
+    if (showType.contain(ShowType.a)) {
+      areaController = new FixedExtentScrollController(
+          initialItem: targetCity.child
+              .indexWhere((Point p) => p.code == targetArea.code));
+    }
     // 增加第4级(村/镇)选择
-    villageController = new FixedExtentScrollController(
-        initialItem: targetArea.child
-            .indexWhere((Point p) => p.code == targetVillage.code));
+    if (showType.contain(ShowType.v)) {
+      villageController = new FixedExtentScrollController(
+          initialItem: targetArea.child
+              .indexWhere((Point p) => p.code == targetVillage.code));
+    }
   }
 
   // 重置Controller的原因在于, 无法手动去更改initialItem, 也无法通过
@@ -130,7 +145,8 @@ class _BaseView extends State<BaseView> {
 
     cityController = new FixedExtentScrollController(initialItem: 0);
     areaController = new FixedExtentScrollController(initialItem: 0);
-    villageController = new FixedExtentScrollController(initialItem: 0);// 增加第4级(村/镇)选择
+    villageController =
+        new FixedExtentScrollController(initialItem: 0); // 增加第4级(村/镇)选择
     _resetControllerOnce = true;
   }
 
@@ -247,7 +263,7 @@ class _BaseView extends State<BaseView> {
         targetProvince = _provinceTree;
         targetCity = _getTargetChildFirst(_provinceTree);
         targetArea = _getTargetChildFirst(targetCity);
-        targetVillage = _getTargetChildFirst(targetArea);// 增加第4级(村/镇)选择
+        targetVillage = _getTargetChildFirst(targetArea); // 增加第4级(村/镇)选择
         _resetController();
       });
     });
@@ -322,7 +338,8 @@ class _BaseView extends State<BaseView> {
       result.cityName = targetCity != null ? targetCity.name : null;
       result.areaId = targetArea != null ? targetArea.code.toString() : null;
       result.areaName = targetArea != null ? targetArea.name : null;
-      result.villageId = targetVillage != null ? targetVillage.code.toString() : null;
+      result.villageId =
+          targetVillage != null ? targetVillage.code.toString() : null;
       result.villageName = targetVillage != null ? targetVillage.name : null;
     }
     // 台湾异常数据. 需要过滤
@@ -419,7 +436,8 @@ class _BaseView extends State<BaseView> {
                       _onAreaChange(targetCity.child[index]);
                     },
                   ),
-                  new _MyCityPicker(// 增加第4级(村/镇)选择
+                  new _MyCityPicker(
+                    // 增加第4级(村/镇)选择
                     key: Key('villages $targetArea'),
                     isShow: widget.showType.contain(ShowType.v),
                     controller: villageController,
@@ -534,28 +552,26 @@ class _MyCityPickerState extends State<_MyCityPicker> {
                 double fontSize = 13;
                 if (text != null) {
                   int len = text.length;
-                  if (len >=1 && len<= 3) {
+                  if (len >= 1 && len <= 3) {
                     fontSize = 20;
-                  } else if (len > 3 && len <=4) {
+                  } else if (len > 3 && len <= 4) {
                     fontSize = 18;
-                  } else if(len > 4 && len <=5) {
+                  } else if (len > 4 && len <= 5) {
                     fontSize = 16;
-                  } else if(len > 5 && len <=6) {
+                  } else if (len > 5 && len <= 6) {
                     fontSize = 12;
-                  } else if(len > 6 && len <=9) {
+                  } else if (len > 6 && len <= 9) {
                     fontSize = 10;
-                  } else if(len > 9) {
+                  } else if (len > 9) {
                     fontSize = 7;
                   }
                 }
                 return Center(
                   child: Text(
                     '$text',
-                    overflow: TextOverflow.ellipsis,// 字数过多时显示省略号
+                    overflow: TextOverflow.ellipsis, // 字数过多时显示省略号
                     maxLines: 1,
-                    style: TextStyle(
-                      fontSize: fontSize
-                    ),
+                    style: TextStyle(fontSize: fontSize),
                   ),
                 );
               },


### PR DESCRIPTION
The address database may only have provincial and municipal levels. After introducing town, the targetArea may be null and can't get a child member.
After modification, initialize according to showType

地址库有可能只有省市两级，引入第4级之后，targetArea为null，取child成员报错
修改后根据showType的需要进行初始化